### PR TITLE
feat: Candlestick API 구현

### DIFF
--- a/Bithumb-CoinTradeApp.xcodeproj/project.pbxproj
+++ b/Bithumb-CoinTradeApp.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		87CCA58827CDCC6F00C5E022 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CCA58727CDCC6F00C5E022 /* UIView+.swift */; };
 		87CCA58A27CDCD5A00C5E022 /* LeaderBoardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CCA58927CDCD5A00C5E022 /* LeaderBoardTableViewCell.swift */; };
 		87CCA58E27CDD99E00C5E022 /* LabelWithRoundImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CCA58D27CDD99E00C5E022 /* LabelWithRoundImageView.swift */; };
+		87E2687C27D3A0B50012753B /* Candlestick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E2687B27D3A0B50012753B /* Candlestick.swift */; };
 		87E7A78527CFA9F700D8C3D9 /* LeaderBoardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E7A78427CFA9F700D8C3D9 /* LeaderBoardViewModel.swift */; };
 		87F002D427C9206B001E8BDC /* TickerAll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F002D327C9206B001E8BDC /* TickerAll.swift */; };
 		87F002D627C9209F001E8BDC /* TickerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F002D527C9209F001E8BDC /* TickerData.swift */; };
@@ -104,6 +105,7 @@
 		87CCA58727CDCC6F00C5E022 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		87CCA58927CDCD5A00C5E022 /* LeaderBoardTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderBoardTableViewCell.swift; sourceTree = "<group>"; };
 		87CCA58D27CDD99E00C5E022 /* LabelWithRoundImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelWithRoundImageView.swift; sourceTree = "<group>"; };
+		87E2687B27D3A0B50012753B /* Candlestick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Candlestick.swift; sourceTree = "<group>"; };
 		87E7A78427CFA9F700D8C3D9 /* LeaderBoardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderBoardViewModel.swift; sourceTree = "<group>"; };
 		87F002D327C9206B001E8BDC /* TickerAll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerAll.swift; sourceTree = "<group>"; };
 		87F002D527C9209F001E8BDC /* TickerData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TickerData.swift; sourceTree = "<group>"; };
@@ -157,19 +159,17 @@
 			isa = PBXGroup;
 			children = (
 				0082D8E327C9153B00E65E72 /* AssetStatus.swift */,
+				87E2687B27D3A0B50012753B /* Candlestick.swift */,
 				0082D8EA27C9163C00E65E72 /* OrderBook.swift */,
-				E5F565A227C924120002599F /* OrderBookData.swift */,
 				E5F565A427C924180002599F /* OrderBookAll.swift */,
-				0082D8EC27C9164500E65E72 /* TransactionHistory.swift */,
-				E598E56D27CF5A21006D7659 /* TransactionHistoryData.swift */,
-				E598E56B27CF55BC006D7659 /* TransactionHistoryViewData.swift */,
-				0082D8E827C915F200E65E72 /* Ticker.swift */,
-				87F002D327C9206B001E8BDC /* TickerAll.swift */,
-				87F002D527C9209F001E8BDC /* TickerData.swift */,
+				E5F565A227C924120002599F /* OrderBookData.swift */,
 				0082D8E827C915F200E65E72 /* Ticker.swift */,
 				87F002D327C9206B001E8BDC /* TickerAll.swift */,
 				87F002D527C9209F001E8BDC /* TickerData.swift */,
 				0082D91427CE5BE700E65E72 /* TickerViewData.swift.swift */,
+				0082D8EC27C9164500E65E72 /* TransactionHistory.swift */,
+				E598E56D27CF5A21006D7659 /* TransactionHistoryData.swift */,
+				E598E56B27CF55BC006D7659 /* TransactionHistoryViewData.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -649,6 +649,7 @@
 				0082D8E927C915F200E65E72 /* Ticker.swift in Sources */,
 				E598E56E27CF5A21006D7659 /* TransactionHistoryData.swift in Sources */,
 				87E7A78527CFA9F700D8C3D9 /* LeaderBoardViewModel.swift in Sources */,
+				87E2687C27D3A0B50012753B /* Candlestick.swift in Sources */,
 				87C6B43F27C65EED00F880DE /* CoinListViewController.swift in Sources */,
 				87C6B44627C6640800F880DE /* PagerViewController.swift in Sources */,
 				87C6B43B27C65DDA00F880DE /* MainTabBarViewController.swift in Sources */,

--- a/Bithumb-CoinTradeApp/Models/Candlestick.swift
+++ b/Bithumb-CoinTradeApp/Models/Candlestick.swift
@@ -1,0 +1,46 @@
+//
+//  Candlestick.swift
+//  Bithumb-CoinTradeApp
+//
+//  Created by 이지원 on 2022/03/05.
+//
+
+import Foundation
+
+struct Candlestick: Codable {
+    let status: String
+    let data: [[CandlestickData]]
+}
+
+enum CandlestickData: Codable {
+    case integer(Int)
+    case string(String)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let x = try? container.decode(Int.self) {
+            self = .integer(x)
+            return
+        }
+        if let x = try? container.decode(String.self) {
+            self = .string(x)
+            return
+        }
+        throw DecodingError.typeMismatch(
+            CandlestickData.self,
+            DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "Wrong type for Datum"
+            ))
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .integer(let x):
+            try container.encode(x)
+        case .string(let x):
+            try container.encode(x)
+        }
+    }
+}

--- a/Bithumb-CoinTradeApp/Network/BithumbEndpointCases.swift
+++ b/Bithumb-CoinTradeApp/Network/BithumbEndpointCases.swift
@@ -13,6 +13,18 @@ enum PaymentCurrency: String {
     case btc = "BTC"
 }
 
+enum ChartIntervals: String {
+    case minutesOf1 = "1m"
+    case minutesOf3 = "3m"
+    case minutesOf5 = "5m"
+    case minutesOf10 = "10m"
+    case minutesOf30 = "30m"
+    case hoursOf1 = "1h"
+    case hoursOf6 = "6h"
+    case hoursOf12 = "12h"
+    case hoursOf24 = "24h"
+}
+
 enum BithumbEndpointCases {
     typealias OrderCurrency = String
     
@@ -20,6 +32,7 @@ enum BithumbEndpointCases {
     case orderBook(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency)
     case transactionHistory(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency)
     case assetsStatus(orderCurrency: OrderCurrency)
+    case candlestick(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency, chartIntervals: ChartIntervals)
 }
 
 extension BithumbEndpointCases: Endpoint {
@@ -41,14 +54,16 @@ extension BithumbEndpointCases: Endpoint {
             return "/transaction_history/\(orderCurrency)_\(paymentCurrency.rawValue)"
         case let .assetsStatus(orderCurrency):
             return "/assetsstatus/\(orderCurrency)"
+        case let .candlestick(orderCurrency, paymentCurrency, chartIntervals):
+            return "/candlestick/\(orderCurrency)_\(paymentCurrency)/\(chartIntervals.rawValue)"
         }
     }
     
     var headers: HTTPHeaders? {
         return nil
     }
-    
-    var body: [String : Any]? {
+
+    var body: [String: Any]? {
         return [:]
     }
 }

--- a/Bithumb-CoinTradeApp/Network/RESTAPIRepository.swift
+++ b/Bithumb-CoinTradeApp/Network/RESTAPIRepository.swift
@@ -12,27 +12,33 @@ import RxSwift
 
 protocol RESTAPIRepositable {
     func requestAssetStatus(orderCurrency: String) -> Single<AssetStatus>
-    
+
     func requestTransactionHistory(
         orderCurrency: String,
         paymentCurrency: PaymentCurrency
     ) -> Single<TransactionHistory>
-    
+
     func requestOrderBook(
         orderCurrency: String,
         paymentCurrency: PaymentCurrency
     ) -> Single<OrderBook>
-    
+
     func requestAllOrderBook(
         paymentCurrency: PaymentCurrency
     ) -> Single<OrderBookAll>
-    
+
     func requestAllTicker(paymentCurrency: PaymentCurrency) -> Single<TickerAll>
-    
+
     func requestTicker(
         orderCurrency: String,
         paymentCurrency: PaymentCurrency
     ) -> Single<Ticker>
+
+    func requestCandlestick(
+        orderCurrency: String,
+        paymentCurrency: PaymentCurrency,
+        chartIntervals: ChartIntervals
+    ) -> Single<Candlestick>
 }
 
 extension RESTAPIRepositable {
@@ -53,7 +59,7 @@ extension RESTAPIRepositable {
                         observer(.failure(error))
                     }
                 }
-            
+
             return Disposables.create { request.cancel() }
         }
     }
@@ -62,11 +68,10 @@ extension RESTAPIRepositable {
 // MARK: - RESTAPIRepository
 
 final class RESTAPIRepository: RESTAPIRepositable {
-    
     func requestAssetStatus(orderCurrency: String) -> Single<AssetStatus> {
         return request(BithumbEndpointCases.assetsStatus(orderCurrency: orderCurrency))
     }
-    
+
     func requestTransactionHistory(
         orderCurrency: String,
         paymentCurrency: PaymentCurrency
@@ -86,7 +91,7 @@ final class RESTAPIRepository: RESTAPIRepositable {
             paymentCurrency: paymentCurrency
         ))
     }
-    
+
     func requestAllOrderBook(
         paymentCurrency: PaymentCurrency
     ) -> Single<OrderBookAll> {
@@ -95,14 +100,14 @@ final class RESTAPIRepository: RESTAPIRepositable {
             paymentCurrency: paymentCurrency
         ))
     }
-    
+
     func requestAllTicker(paymentCurrency: PaymentCurrency) -> Single<TickerAll> {
         return request(BithumbEndpointCases.ticker(
             orderCurrency: "ALL",
             paymentCurrency: paymentCurrency
         ))
     }
-        
+
     func requestTicker(
         orderCurrency: String,
         paymentCurrency: PaymentCurrency
@@ -110,6 +115,18 @@ final class RESTAPIRepository: RESTAPIRepositable {
         return request(BithumbEndpointCases.ticker(
             orderCurrency: orderCurrency,
             paymentCurrency: paymentCurrency
+        ))
+    }
+
+    func requestCandlestick(
+        orderCurrency: String,
+        paymentCurrency: PaymentCurrency,
+        chartIntervals: ChartIntervals
+    ) -> Single<Candlestick> {
+        return request(BithumbEndpointCases.candlestick(
+            orderCurrency: orderCurrency,
+            paymentCurrency: paymentCurrency,
+            chartIntervals: chartIntervals
         ))
     }
 }


### PR DESCRIPTION
## 개요

차트 표시를 위한 Candlestick API 구현

## 작업 사항

- Endpoint cases 에 Candlestick 추가
- Candlestick 모델 구현
- requestCandlestick 메서드 구현

## 비고

SwiftLInt에서 재영, 힉스의 viewModel 쪽 sample data의 라인 수 제한으로 인해 build 가 안되는데 해당 부분은 수정하지 않았습니다.