### PR TITLE
웹소켓 로직 개선 및 코인목록 화면 개선

### DIFF
--- a/Bithumb-CoinTradeApp.xcodeproj/project.pbxproj
+++ b/Bithumb-CoinTradeApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0026D86027D4A01200B40A6F /* WebSocketService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0026D85F27D4A01200B40A6F /* WebSocketService.swift */; };
 		0026D86227D4A36A00B40A6F /* WebSocketInitResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0026D86127D4A36A00B40A6F /* WebSocketInitResponse.swift */; };
 		0026D86427D4B46F00B40A6F /* WebSocketError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0026D86327D4B46F00B40A6F /* WebSocketError.swift */; };
+		0026D86727D636BF00B40A6F /* Double+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0026D86627D636BF00B40A6F /* Double+.swift */; };
 		003F5E5727D10C4A001D76C2 /* WebSocketRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003F5E5627D10C4A001D76C2 /* WebSocketRepository.swift */; };
 		0082D8E127C7CE8D00E65E72 /* RESTAPIRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0082D8E027C7CE8D00E65E72 /* RESTAPIRepository.swift */; };
 		0082D8E427C9153B00E65E72 /* AssetStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0082D8E327C9153B00E65E72 /* AssetStatus.swift */; };
@@ -82,6 +83,7 @@
 		0026D85F27D4A01200B40A6F /* WebSocketService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketService.swift; sourceTree = "<group>"; };
 		0026D86127D4A36A00B40A6F /* WebSocketInitResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketInitResponse.swift; sourceTree = "<group>"; };
 		0026D86327D4B46F00B40A6F /* WebSocketError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketError.swift; sourceTree = "<group>"; };
+		0026D86627D636BF00B40A6F /* Double+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+.swift"; sourceTree = "<group>"; };
 		003F5E5627D10C4A001D76C2 /* WebSocketRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketRepository.swift; sourceTree = "<group>"; };
 		0082D8E027C7CE8D00E65E72 /* RESTAPIRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTAPIRepository.swift; sourceTree = "<group>"; };
 		0082D8E327C9153B00E65E72 /* AssetStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetStatus.swift; sourceTree = "<group>"; };
@@ -369,6 +371,7 @@
 			isa = PBXGroup;
 			children = (
 				87CCA58727CDCC6F00C5E022 /* UIView+.swift */,
+				0026D86627D636BF00B40A6F /* Double+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -676,6 +679,7 @@
 				878D0F0127C4F3B40006D255 /* ViewController.swift in Sources */,
 				0082D8ED27C9164500E65E72 /* TransactionHistory.swift in Sources */,
 				0082D8E427C9153B00E65E72 /* AssetStatus.swift in Sources */,
+				0026D86727D636BF00B40A6F /* Double+.swift in Sources */,
 				0082D8EB27C9163C00E65E72 /* OrderBook.swift in Sources */,
 				E598E56827CF4C89006D7659 /* TransactionHistoryViewController.swift in Sources */,
 				87C6B43F27C65EED00F880DE /* CoinListViewController.swift in Sources */,

--- a/Bithumb-CoinTradeApp/Application/SceneDelegate.swift
+++ b/Bithumb-CoinTradeApp/Application/SceneDelegate.swift
@@ -20,16 +20,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = navigationController
         
         let restAPIRepository = RESTAPIRepository()
-        let webSocketService = WebSocketService(repository: WebSocketRepository())
         
-        coordinator = CoinCoordinator(
-            navigationController: navigationController,
-            restAPIRepository: restAPIRepository,
-            webSocketService: webSocketService
-        )
-        coordinator?.start()
-        
-        window?.makeKeyAndVisible()
+        do {
+            let webSocketService = try WebSocketService(repository: WebSocketRepository())
+            
+            coordinator = CoinCoordinator(
+                navigationController: navigationController,
+                restAPIRepository: restAPIRepository,
+                webSocketService: webSocketService
+            )
+            coordinator?.start()
+            
+            window?.makeKeyAndVisible()
+        } catch {
+            print(error)
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Bithumb-CoinTradeApp/Models/TickerViewData.swift.swift
+++ b/Bithumb-CoinTradeApp/Models/TickerViewData.swift.swift
@@ -45,4 +45,8 @@ extension TickerViewData {
     var tradedCount: Double {
         Double(unitsTraded) ?? 0
     }
+    
+    var price: Double {
+        Double(currentPrice) ?? 0
+    }
 }

--- a/Bithumb-CoinTradeApp/Modules/CoinList/CoinCell.swift
+++ b/Bithumb-CoinTradeApp/Modules/CoinList/CoinCell.swift
@@ -111,7 +111,7 @@ class CoinCell: UITableViewCell {
         
         coinNameLabel.text = viewData.coinName
         
-        let priceAttributedString = NSMutableAttributedString(string: viewData.currentPrice + "원  ")
+        let priceAttributedString = NSMutableAttributedString(string: viewData.price.toCurrencyFormat + "원  ")
         let fluctateRateAttributedString = NSMutableAttributedString(
             string: "\(viewData.fluctateRate)%",
             attributes: [

--- a/Bithumb-CoinTradeApp/Modules/CoinList/CoinListViewController.swift
+++ b/Bithumb-CoinTradeApp/Modules/CoinList/CoinListViewController.swift
@@ -227,7 +227,7 @@ final class CoinListViewController: BaseViewController {
         snapShot.appendSections([0])
         snapShot.appendItems(coins)
         
-        dataSource?.apply(snapShot)
+        dataSource?.apply(snapShot, animatingDifferences: false)
     }
     
     private func didTapLikeButton(_ coinName: String) {

--- a/Bithumb-CoinTradeApp/Network/WebSocket/WebSocketError.swift
+++ b/Bithumb-CoinTradeApp/Network/WebSocket/WebSocketError.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum WebSocketError: Error {
+    case invalidURL
     case decodingError
     case invalidFilter
 }

--- a/Bithumb-CoinTradeApp/Network/WebSocket/WebSocketService.swift
+++ b/Bithumb-CoinTradeApp/Network/WebSocket/WebSocketService.swift
@@ -26,7 +26,6 @@ protocol WebSocketServiceType {
 class WebSocketService: WebSocketServiceType {
     let repository: WebSocketRepositable
     let disposeBag = DisposeBag()
-    private var currentSubscriptionType: SubscriptionType?
     
     init(repository: WebSocketRepositable) {
         self.repository = repository
@@ -37,8 +36,6 @@ class WebSocketService: WebSocketServiceType {
         coinNames: [String],
         paymentCurrency: PaymentCurrency
     ) -> Observable<T> {
-        currentSubscriptionType = .ticker
-
         return repository.requestData(
             type: type,
             coinNames: coinNames,

--- a/Bithumb-CoinTradeApp/Utils/Extension/Double+.swift
+++ b/Bithumb-CoinTradeApp/Utils/Extension/Double+.swift
@@ -1,0 +1,17 @@
+//
+//  Double+.swift
+//  Bithumb-CoinTradeApp
+//
+//  Created by jaeyoung Yun on 2022/03/07.
+//
+
+import Foundation
+
+extension Double {
+    var toCurrencyFormat: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        
+        return formatter.string(from: NSNumber(floatLiteral: self)) ?? "0"
+    }
+}


### PR DESCRIPTION
## 웹소켓 로직 개선

- 기존에 웹소켓이 연결이 아직 되지 않았을 경우에 데이터 요청을 할 때  
데이터 요청이 씹히는 상황을 방지하기 위해 차선책으로 코인 목록화면에서 2초뒤 데이터 요청을 하는 꼼수?를 사용하였습니다.

  이것을 웹소켓 리포지토리에서 웹소켓 연결이 되지 않았을 경우 데이터 요청 정보를 저장하고 있다가
  웹소켓 연결이 완료되면 가지고 있던 데이터 요청 정보를 통해 데이터를 요청하는 방식으로 개선하였습니다.


- 웹소켓 연결 request에서 url이 강제 언래핑 되어있는 부분을 강제 언래핑을 사용하지 않고
WebSocketError.invalidURL 에러를 던지는 방식으로 수정하였습니다.

## 코인 목록 화면 개선

- 원화 목록을 가격 순으로 정렬하였습니다.
- 웹소켓 데이터 때문에 가격 변동 시 셀이 움직이는 현상을 수정하였습니다.
- 관심과 인기 목록이 웹소켓 데이터 때문에 리로드 시 원화 목록으로 되는 버그를 수정하였습니다.
- 가격 표시에 콤마를 추가하였습니다.